### PR TITLE
feat: Update Next.js image config to use remotePatterns

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,18 +6,17 @@ const nextConfig: NextConfig = {
 
   // Configure domains for external images
   images: {
-    domains: [
-      'images.unsplash.com',
-      'via.placeholder.com',
-      'picsum.photos',
-      'i.imgur.com',
-      'i.ibb.co',
-      'upload.wikimedia.org',
-      'www.w3schools.com',
-      'cdn.pixabay.com',
-      'www.freepnglogos.com',
-      'upload.wikimedia.org',
-      'i.gyazo.com',
+    remotePatterns: [
+      { protocol: 'https', hostname: 'images.unsplash.com' },
+      { protocol: 'https', hostname: 'via.placeholder.com' },
+      { protocol: 'https', hostname: 'picsum.photos' },
+      { protocol: 'https', hostname: 'i.imgur.com' },
+      { protocol: 'https', hostname: 'i.ibb.co' },
+      { protocol: 'https', hostname: 'upload.wikimedia.org' },
+      { protocol: 'https', hostname: 'www.w3schools.com' },
+      { protocol: 'https', hostname: 'cdn.pixabay.com' },
+      { protocol: 'https', hostname: 'www.freepnglogos.com' },
+      { protocol: 'https', hostname: 'i.gyazo.com' },
     ],
   },
 };


### PR DESCRIPTION
Updates the Next.js image configuration to use the modern `remotePatterns` array instead of the deprecated `domains` array. This allows for more secure and flexible whitelisting of image sources.

The existing list of whitelisted domains has been migrated to the new format. This change should fix issues where images from whitelisted domains were not being displayed.

Changes made by JULES